### PR TITLE
Use webdriver-manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# Avito Parser
+
+This script parses Avito listings using Selenium. To install dependencies, run:
+
+```bash
+pip install -r requierments.txt
+```
+
+The script now uses `webdriver-manager` to download a compatible ChromeDriver automatically. Simply run:
+
+```bash
+python main.py
+```
+
+You will be prompted for the product name and number of listings to parse.

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 from selenium import webdriver
 from selenium.webdriver.common.by import By
+from selenium.webdriver.chrome.service import Service
+from webdriver_manager.chrome import ChromeDriverManager
 import json
 import datetime
 
@@ -56,7 +58,7 @@ def pubdate_correct(pubdate):
 
 
 
-driver = webdriver.Chrome(options=options)
+driver = webdriver.Chrome(service=Service(ChromeDriverManager().install()), options=options)
 count = 0
 
 try:

--- a/requierments.txt
+++ b/requierments.txt
@@ -1,4 +1,7 @@
 #pip
 selenium
+# Added for automatic ChromeDriver management
+webdriver-manager
 #chrome
 chrome ver 107.0.5304.*
+


### PR DESCRIPTION
## Summary
- use webdriver-manager to manage ChromeDriver
- document setup steps
- list webdriver-manager in requirements

## Testing
- `python3 -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684491636ad0832b8b6e201ffafad237